### PR TITLE
:sparkles: Added fields to cardSchema for binders and boxes

### DIFF
--- a/backend/src/cards/schemas/card.schema.ts
+++ b/backend/src/cards/schemas/card.schema.ts
@@ -43,6 +43,12 @@ export class Card {
 
   @Prop({ required: true, default: 0 })
   availableCopies: number;
+
+  @Prop({ required: false })
+  boxLocation: string;
+
+  @Prop({ required: false })
+  binderLocation: string;
 }
 
 export const CardSchema = SchemaFactory.createForClass(Card);


### PR DESCRIPTION
Users can now specify a name of a binder or box for where the card is being stored in real life.